### PR TITLE
fix(src): Fix the copy method in the Filesystem class to ensure that …

### DIFF
--- a/Filesystem.php
+++ b/Filesystem.php
@@ -21,7 +21,14 @@ final class Filesystem
             if ($file === '.' || $file === '..') {
                 continue;
             }
-            \Nette\Utils\FileSystem::copy($source . '/' . $file, $target . '/' . $file);
+
+            $sourcePath = $source . '/' . $file;
+            $targetPath = $target . '/' . $file;
+            if (is_dir($sourcePath)) {
+                self::copy($sourcePath, $targetPath, $deleteSource);
+            } else {
+                \Nette\Utils\FileSystem::copy($sourcePath, $targetPath);
+            }
         }
         if ($deleteSource) {
             \Nette\Utils\FileSystem::delete($source);


### PR DESCRIPTION
…when a folder in source contains a folder with the same name as target, the files in the target folder are not overwritten.